### PR TITLE
PR_erlang-p1-oauth2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,15 +22,6 @@ otp_release:
   - 18.1
   - 22.3
   - 23.0
-# Disable otp_release 17.1, 17.5 & 18.1 as these releases are not supported on Ubuntu16.04 for arch: ppc64le
-jobs: 
- exclude:
-  - arch: ppc64le
-      otp_release 17.1
-  - arch: ppc64le
-      otp_release 17.5
-  - arch: ppc64le
-      otp_release 18.1
 
 after_success:
   - cpp-coveralls --exclude lib --exclude tests --gcov-options '\-lp' --dump c.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ dist: xenial
 
 before_install:
   - pip install --user cpp-coveralls coveralls-merge
+  - if [ "$TRAVIS_ARCH" = "ppc64le" ]; then sudo apt-get update; sudo apt-get install rebar; fi
 
 install:
   - rebar -C rebar.test.config get-deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,12 @@ otp_release:
   - 23.0
 # Disable otp_release 17.1, 17.5 & 18.1 as these releases are not supported on Ubuntu16.04 for arch: ppc64le
 jobs: 
-  exclude:
-    - arch: ppc64le
+ exclude:
+  - arch: ppc64le
       otp_release 17.1
-    - arch: ppc64le
+  - arch: ppc64le
       otp_release 17.5
-    - arch: ppc64le
+  - arch: ppc64le
       otp_release 18.1
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: erlang
+arch:
+  - ppc64le
+  - amd64
 
 os: linux
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ dist: xenial
 
 before_install:
   - pip install --user cpp-coveralls coveralls-merge
-  - if [ "$TRAVIS_ARCH" = "ppc64le" ]; then sudo apt-get update; sudo apt-get install rebar; fi
+ # - if [ "$TRAVIS_ARCH" = "ppc64le" ]; then sudo apt-get update; sudo apt-get install rebar; fi
 
 install:
   - rebar -C rebar.test.config get-deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,15 @@ otp_release:
   - 18.1
   - 22.3
   - 23.0
+# Disable otp_release 17.1, 17.5 & 18.1 as these releases are not supported on Ubuntu16.04 for arch: ppc64le
+jobs: 
+  exclude:
+    - arch: ppc64le
+      otp_release 17.1
+    - arch: ppc64le
+      otp_release 17.5
+    - arch: ppc64le
+      otp_release 18.1
 
 after_success:
   - cpp-coveralls --exclude lib --exclude tests --gcov-options '\-lp' --dump c.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,30 @@
 language: erlang
 arch:
-  - ppc64le
   - amd64
-
+  - ppc64le
 os: linux
-
 dist: xenial
-
 before_install:
   - pip install --user cpp-coveralls coveralls-merge
- # - if [ "$TRAVIS_ARCH" = "ppc64le" ]; then sudo apt-get update; sudo apt-get install rebar; fi
-
+  - if [ "$TRAVIS_ARCH" = "ppc64le" ]; then sudo apt-get update; sudo apt-get install rebar; fi
 install:
   - rebar -C rebar.test.config get-deps
-
 script: rebar -C rebar.test.config compile xref && rebar -C rebar.test.config eunit skip_deps=true
-
 otp_release:
   - 17.1
   - 17.5
   - 18.1
   - 22.3
   - 23.0
-
+# Disable otp_release 17.1, 17.5 & 18.1 as these releases are not supported on Ubuntu16.04 for arch: ppc64le
+jobs: 
+ exclude:
+  - arch: ppc64le
+    otp_release: 17.1
+  - arch: ppc64le
+    otp_release: 17.5
+  - arch: ppc64le
+    otp_release: 18.1
 after_success:
   - cpp-coveralls --exclude lib --exclude tests --gcov-options '\-lp' --dump c.json
   - coveralls-merge c.json erlang.json


### PR DESCRIPTION
Adding power support ppc64le

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

Erlang17.1/17.5/18.1 releases are not supported for ppc64le on ubuntu16.04.
Please refer to this documentation Link - https://docs.travis-ci.com/user/languages/erlang/#otprelease-versions

Hence the Travis.yml file has been modified to exclude the above OTP Releases for arch: ppc64le/Ubuntu 16.04
The Build is successful for rest all., Please refer the Link: https://travis-ci.com/github/santosh653/p1_oauth2.



