### PR TITLE
Look for the correct value when returning `undefined`

### DIFF
--- a/src/oauth2_response.erl
+++ b/src/oauth2_response.erl
@@ -145,7 +145,7 @@ refresh_token(Response, NewRefreshToken) ->
     Response#response{refresh_token = NewRefreshToken}.
 
 -spec refresh_token_expires_in(response()) -> {ok, lifetime()} | {error, not_set}.
-refresh_token_expires_in(#response{refresh_token = undefined})    ->
+refresh_token_expires_in(#response{refresh_token_expires_in = undefined})    ->
     {error, not_set};
 refresh_token_expires_in(#response{refresh_token_expires_in = RefreshTokenExpiresIn}) ->
     {ok, RefreshTokenExpiresIn}.


### PR DESCRIPTION
This fixes an identifier name that allows more of the property tests to pass